### PR TITLE
fix(appfooter.vue): add missing icon props to social link buttons

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -29,7 +29,7 @@
             <NuxtLink to="/huggingface" class="text-white hover:underline">
               {{ $t('social.huggingface') }}
             </NuxtLink>
-            <span class="mx-2 border-l border-gray-600/50"/>
+            <span class="mx-2 border-l border-gray-600/50"></span>
             <NuxtLink to="/github" class="text-white hover:underline">
               {{ $t('social.github') }}
             </NuxtLink>


### PR DESCRIPTION
Social link buttons were invisible. Added missing `icon` property to the config array and bound it to the `UButton` component.