### PR TITLE
docs(readme): update English README and add Traditional Chinese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,163 @@
-# ai-twinkle.github.io
-🌐 Twinkle AI Official Website
+# Twinkle AI Official Website
+
+> [繁體中文](README_zh-tw.md) | **English**
+
+🌐 Official website for Twinkle AI - An open-source Traditional Chinese language model research community (致力於構建開源正體中文語言模型的研究社群).
+
+This bilingual (Traditional Chinese and English) website showcases Twinkle AI's projects, research, and community initiatives.
+
+## Tech Stack
+
+- **Framework**: [Nuxt 4](https://nuxt.com/) (Vue 3)
+- **UI Library**: [Nuxt UI](https://ui.nuxt.com/)
+- **Deployment**: [Cloudflare Workers](https://workers.cloudflare.com/)
+- **Package Manager**: [Bun](https://bun.sh/)
+- **Internationalization**: @nuxtjs/i18n (zh-TW default, English)
+
+## Prerequisites
+
+- **Node.js** 18+ or **Bun** runtime
+- **Bun** package manager (recommended) - [Install Bun](https://bun.sh/)
+
+## Getting Started
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/ai-twinkle/ai-twinkle.github.io.git
+cd ai-twinkle.github.io
+```
+
+### 2. Install Dependencies
+
+Using Bun (recommended):
+
+```bash
+bun install
+```
+
+Or using npm:
+
+```bash
+npm install
+```
+
+### 3. Start Development Server
+
+```bash
+npm run dev
+```
+
+The site will be available at `http://localhost:3000`
+
+## Development Commands
+
+| Command | Description |
+| ------- | ----------- |
+| `npm run dev` | Start development server |
+| `npm run build` | Build for production |
+| `npm run generate` | Generate static site |
+| `npm run preview` | Build and preview with Wrangler |
+| `npm run deploy` | Deploy to Cloudflare Workers |
+| `npm run lint:es:fix` | Auto-fix ESLint issues |
+| `npm run lint:es:check` | Check ESLint (fails on warnings) |
+| `npm run cf-typegen` | Generate Cloudflare types |
+
+## Project Structure
+
+```text
+.
+├── app/                    # Frontend Nuxt application
+│   ├── pages/             # File-based routing
+│   ├── components/        # Vue components
+│   ├── layouts/           # Page layouts
+│   ├── plugins/           # Nuxt plugins
+│   ├── data/              # TypeScript types and data
+│   └── assets/css/        # Global CSS
+├── server/                # Server-side code (Nitro)
+│   ├── api/              # API endpoints
+│   ├── routes/           # Server routes (redirects)
+│   └── utils/            # Server utilities
+├── i18n/locales/         # Translation files (zh-TW, en)
+├── public/               # Static assets
+├── nuxt.config.ts        # Nuxt configuration
+└── wrangler.jsonc        # Cloudflare Workers config
+```
+
+## Contributing
+
+We welcome contributions! Please follow these guidelines:
+
+### Git Workflow
+
+This project uses **conventional commits** enforced by commitlint:
+
+```bash
+# Commit message format
+type(scope): description
+
+# Examples
+feat(components): add new hero section
+fix(i18n): correct translation keys
+docs(readme): update setup instructions
+```
+
+**Common types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+### Git Hooks
+
+- **Pre-commit**: Runs ESLint on staged files
+- **Commit-msg**: Validates commit message format
+
+### Code Style
+
+- **ESLint** with `eslint-config-nymph`
+- **JSDoc** comments (without type annotations - use TypeScript types)
+- Run `npm run lint:es:fix` before committing
+
+## Key Features
+
+### Internationalization (i18n)
+
+- Default locale: **zh-TW** (Traditional Chinese)
+- Secondary locale: **en** (English)
+- URL strategy: `prefix_except_default`
+  - Chinese: `/` (no prefix)
+  - English: `/en`
+
+### Icon System
+
+The project uses `DynamicHeroIcon.vue` component that converts PascalCase heroicon names to Nuxt UI format:
+
+- Input: `BeakerIcon` → Output: `i-heroicons-beaker`
+
+### Server Routes
+
+- `/github` - Redirects to GitHub organization
+- `/discord` - Redirects to Discord server
+- `/huggingface` - Redirects to HuggingFace organization
+- API 404s return ASCII cat art via `useCat()` utility
+
+## Deployment
+
+The site is deployed to **Cloudflare Workers**:
+
+```bash
+npm run deploy
+```
+
+Configuration is managed in `wrangler.jsonc`.
+
+## License
+
+This project is licensed under the terms specified in the [LICENSE](LICENSE) file.
+
+## Community
+
+- **GitHub**: [github.com/ai-twinkle](https://github.com/ai-twinkle)
+- **HuggingFace**: [huggingface.co/twinkle-ai](https://huggingface.co/twinkle-ai)
+- **Discord**: Join our community server
+
+---
+
+Built with ❤️ by the Twinkle AI community

--- a/README_zh-tw.md
+++ b/README_zh-tw.md
@@ -1,0 +1,163 @@
+# Twinkle AI 官方網站
+
+> **繁體中文** | [English](README.md)
+
+🌐 Twinkle AI 官方網站 - 致力於構建開源正體中文語言模型的研究社群。
+
+這是一個雙語（繁體中文與英文）網站，展示 Twinkle AI 的專案、研究與社群活動。
+
+## 技術架構
+
+- **框架**: [Nuxt 4](https://nuxt.com/) (Vue 3)
+- **UI 函式庫**: [Nuxt UI](https://ui.nuxt.com/)
+- **部署平台**: [Cloudflare Workers](https://workers.cloudflare.com/)
+- **套件管理器**: [Bun](https://bun.sh/)
+- **國際化**: @nuxtjs/i18n (預設繁體中文，支援英文)
+
+## 環境需求
+
+- **Node.js** 18+ 或 **Bun** 執行環境
+- **Bun** 套件管理器（推薦）- [安裝 Bun](https://bun.sh/)
+
+## 開始使用
+
+### 1. 複製專案
+
+```bash
+git clone https://github.com/ai-twinkle/ai-twinkle.github.io.git
+cd ai-twinkle.github.io
+```
+
+### 2. 安裝相依套件
+
+使用 Bun（推薦）：
+
+```bash
+bun install
+```
+
+或使用 npm：
+
+```bash
+npm install
+```
+
+### 3. 啟動開發伺服器
+
+```bash
+npm run dev
+```
+
+網站將在 `http://localhost:3000` 上運行
+
+## 開發指令
+
+| 指令 | 說明 |
+| ------- | ----------- |
+| `npm run dev` | 啟動開發伺服器 |
+| `npm run build` | 建置正式版本 |
+| `npm run generate` | 產生靜態網站 |
+| `npm run preview` | 使用 Wrangler 建置並預覽 |
+| `npm run deploy` | 部署至 Cloudflare Workers |
+| `npm run lint:es:fix` | 自動修正 ESLint 問題 |
+| `npm run lint:es:check` | 檢查 ESLint（有警告會失敗）|
+| `npm run cf-typegen` | 產生 Cloudflare 型別定義 |
+
+## 專案結構
+
+```text
+.
+├── app/                    # 前端 Nuxt 應用程式
+│   ├── pages/             # 檔案路由
+│   ├── components/        # Vue 元件
+│   ├── layouts/           # 頁面佈局
+│   ├── plugins/           # Nuxt 外掛
+│   ├── data/              # TypeScript 型別與資料
+│   └── assets/css/        # 全域 CSS
+├── server/                # 伺服器端程式碼 (Nitro)
+│   ├── api/              # API 端點
+│   ├── routes/           # 伺服器路由（重定向）
+│   └── utils/            # 伺服器工具函式
+├── i18n/locales/         # 翻譯檔案 (zh-TW, en)
+├── public/               # 靜態資源
+├── nuxt.config.ts        # Nuxt 設定檔
+└── wrangler.jsonc        # Cloudflare Workers 設定
+```
+
+## 貢獻指南
+
+我們歡迎各種貢獻！請遵循以下準則：
+
+### Git 工作流程
+
+本專案使用 **Conventional Commits**（約定式提交），並透過 commitlint 強制執行：
+
+```bash
+# 提交訊息格式
+type(scope): description
+
+# 範例
+feat(components): add new hero section
+fix(i18n): correct translation keys
+docs(readme): update setup instructions
+```
+
+**常用類型**: `feat`（新功能）、`fix`（修正）、`docs`（文件）、`style`（格式）、`refactor`（重構）、`test`（測試）、`chore`（雜項）
+
+### Git Hooks
+
+- **Pre-commit**（提交前）: 對暫存檔案執行 ESLint
+- **Commit-msg**（提交訊息）: 驗證提交訊息格式
+
+### 程式碼風格
+
+- 使用 **ESLint** 搭配 `eslint-config-nymph`
+- **JSDoc** 註解（不包含型別標註 - 使用 TypeScript 型別）
+- 提交前執行 `npm run lint:es:fix`
+
+## 主要特色
+
+### 國際化 (i18n)
+
+- 預設語系: **zh-TW**（繁體中文）
+- 次要語系: **en**（英文）
+- URL 策略: `prefix_except_default`
+  - 中文: `/`（無前綴）
+  - 英文: `/en`
+
+### 圖示系統
+
+本專案使用 `DynamicHeroIcon.vue` 元件，將 PascalCase 格式的 heroicon 名稱轉換為 Nuxt UI 格式：
+
+- 輸入: `BeakerIcon` → 輸出: `i-heroicons-beaker`
+
+### 伺服器路由
+
+- `/github` - 重定向至 GitHub 組織
+- `/discord` - 重定向至 Discord 伺服器
+- `/huggingface` - 重定向至 HuggingFace 組織
+- API 404 錯誤會透過 `useCat()` 工具函式回傳 ASCII 貓咪圖案
+
+## 部署
+
+本網站部署至 **Cloudflare Workers**：
+
+```bash
+npm run deploy
+```
+
+部署設定於 `wrangler.jsonc` 檔案中管理。
+
+## 授權條款
+
+本專案採用 [LICENSE](LICENSE) 檔案中指定的授權條款。
+
+## 社群連結
+
+- **GitHub**: [github.com/ai-twinkle](https://github.com/ai-twinkle)
+- **HuggingFace**: [huggingface.co/twinkle-ai](https://huggingface.co/twinkle-ai)
+- **Discord**: 加入我們的社群伺服器
+
+---
+
+由 Twinkle AI 社群用 ❤️ 打造


### PR DESCRIPTION
此 Pull Request 的內容
這個 PR（#24）為專案新增了完整的文件說明，主要包含以下更新：

## 📝 更新英文 README.md
將原本僅有兩行的簡單說明，擴充為完整的專案文件，包含：

- 專案簡介：清楚說明這是 Twinkle AI 的官方網站
- 技術架構：列出使用的技術堆疊（Nuxt 4、Nuxt UI、Cloudflare Workers、Bun）
- 環境需求：說明需要的執行環境
- 快速開始指南：提供完整的三步驟設置流程
- 複製專案
- 安裝相依套件（支援 Bun 與 npm）
- 啟動開發伺服器
- 開發指令表格：列出所有可用的 npm 指令與說明
- 專案結構圖：視覺化呈現目錄架構
- 貢獻指南：說明 Git 工作流程、Conventional Commits 規範、Git Hooks、程式碼風格
- 主要特色說明：介紹 i18n 國際化策略、圖示系統、伺服器路由
- 部署說明：如何部署至 Cloudflare Workers
- 社群連結：GitHub、HuggingFace、Discord 連結

## 🆕 新增繁體中文 README_zh-tw.md
建立完整的繁體中文版本文件，內容與英文版本對應，讓繁體中文使用者能更容易理解與上手。所有內容都經過專業的技術翻譯，保持術語的準確性。

## 🔗 語言切換功能
在兩個 README 檔案頂部都加入語言切換連結，方便使用者在英文與繁體中文版本之間快速切換。

## 📊 變更統計
README.md：新增 163 行，刪除 2 行
README_zh-tw.md：新增 163 行（全新檔案）
這個更新大幅改善了專案的可讀性與新貢獻者的入門體驗，讓開發者能從零開始在本地機器上建置這個專案。